### PR TITLE
FHIR-52607 Mandatory element consistently represented as min > 0

### DIFF
--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -21,7 +21,7 @@ Implementers are advised to be familiar with the requirements of the FHIR standa
 #### AU PS Profiles and Extensions
 The [Profiles and Extensions](profiles-and-extensions.html) page lists the AU PS profiles and extensions defined for this implementation guide. An AU PS profile [StructureDefinition](http://hl7.org/fhir/R4/structuredefinition.html) defines the minimum elements, extensions, vocabularies and value sets that **SHALL** be present and constrains the way elements are used when conforming to the profile.
 
-AU PS profile elements include mandatory and *Must Support* requirements. [Mandatory elements](#mandatory-elements) are required and have a minimum cardinality of 1 (min=1). [Must Support](#must-support-and-obligation) elements have defined conformance obligations in AU PS.
+AU PS profile elements include mandatory and *Must Support* requirements. [Mandatory elements](#mandatory-elements) are required and have a minimum cardinality > 0. [Must Support](#must-support-and-obligation) elements have defined conformance obligations in AU PS.
 
 #### AU PS Actors
 The [Actor Definitions](actors.html) page lists the AU PS actors defined for this implementation guide and the requirements for implementing that actor. An AU PS profile [StructureDefinition](http://hl7.org/fhir/R4/structuredefinition.html) defines the obligations for an AU PS actor when implementing that profile.


### PR DESCRIPTION
[FHIR-52607](https://jira.hl7.org/browse/FHIR-52607)

Updated wording for mandatory element from "Mandatory elements are required and have a minimum cardinality of 1 (min=1)." to "Mandatory elements are required and have a minimum cardinality > 0." for consistency.