### PR TITLE
FHIR-52408 Rename “Example Use Case” menu item to Use Cases to avoid confusion with “Examples”

### DIFF
--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -48,7 +48,7 @@
     </ul>
   </li>
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Example Use Cases
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Use Cases
       <b class="caret"></b>
     </a>
      <ul class="dropdown-menu">


### PR DESCRIPTION
[FHIR-52408](https://jira.hl7.org/browse/FHIR-52408)

Rename “Example Use Case” menu item to Use Cases to avoid confusion with “Examples”

Note: We may also wish to update the page title from Example Use Cases as well:
<img width="1691" height="811" alt="image" src="https://github.com/user-attachments/assets/000eb020-9c0d-4cf1-b0ba-a33673adaaf3" />
