### PR TITLE
Added CodeableConceptIPS to Encounter.serviceType, Encounter.participant.type, and Encounter.reasonCode in AU PS Encounter FHIR-51872

### DIFF
--- a/input/resources/au-ps-encounter.xml
+++ b/input/resources/au-ps-encounter.xml
@@ -98,6 +98,10 @@
         </extension>
       </extension>
       <path value="Encounter.serviceType"/>
+      <type>
+				<code value="CodeableConcept"/>
+				<profile value="http://hl7.org/fhir/uv/ips/StructureDefinition/CodeableConcept-uv-ips"/>
+			</type>
     </element>
     <element id="Encounter.subject">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
@@ -188,6 +192,10 @@
         </extension>
       </extension>
       <path value="Encounter.participant.type"/>
+      <type>
+				<code value="CodeableConcept"/>
+				<profile value="http://hl7.org/fhir/uv/ips/StructureDefinition/CodeableConcept-uv-ips"/>
+			</type>
     </element>
     <element id="Encounter.participant.individual">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
@@ -275,6 +283,10 @@
         </extension>
       </extension>
       <path value="Encounter.reasonCode"/>
+      <type>
+				<code value="CodeableConcept"/>
+				<profile value="http://hl7.org/fhir/uv/ips/StructureDefinition/CodeableConcept-uv-ips"/>
+			</type>
     </element>
     <element id="Encounter.reasonReference">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">


### PR DESCRIPTION
[FHIR-51872](https://jira.hl7.org/browse/FHIR-51872)
Applied the CodeableConceptIPS data type profile to the following Must Support elements in AU PS Encounter:
- Encounter.serviceType
- Encounter.participant.type
- Encounter.reasonCode

These elements were missing alignment with other AU PS profiles where Must Support CodeableConcept elements already have this constraint. Applying CodeableConceptIPS ensures consistent interpretation and obligations for CodeableConcept usage across the AU PS IG.

Files changed: input/resources/StructureDefinition-au-ps-encounter.xml