### PR TITLE
AU PS Patient: add SHOULD:able-to-populate to Patient.name.text; add IPS guidance text in element comment (FHIR-51877)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -53,7 +53,7 @@ This change log documents the significant updates and resolutions implemented fr
 - [AU PS Patient](StructureDefinition-au-ps-patient.html):
   - changed Patient.contact.relationship to remove use of the CodableConceptIPS [IPS: FHIR-51257](https://jira.hl7.org/browse/FHIR-51257)
   - added SHOULD:able-to-populate obligation on Patient.name.text for the AU PS Producer [FHIR-51877](https://jira.hl7.org/browse/FHIR-51877)
-  - added a comment on Patient.name.text explaining how to use this element based on IPS guidance [FHIR-51877](https://jira.hl7.org/browse/FHIR-51877)
+  - added a comment to Patient.name.text strongly recommending population of this element based on IPS guidance [FHIR-51877](https://jira.hl7.org/browse/FHIR-51877)
 - [AU PS PractitionerRole](StructureDefinition-au-ps-practitionerrole.html):
   - applied technical correction to add obligations SHALL:populate-if-known for the AU PS Producer, and SHALL:handle and SHOULD:display for the AU PS Consumer to PractitionerRole.telecom.system [FHIR-52837](https://jira.hl7.org/browse/FHIR-52837)
   - applied technical correction to add obligations SHALL:populate-if-known for the AU PS Producer, and SHALL:handle and SHOULD:display for the AU PS Consumer to PractitionerRole.telecom.value [FHIR-52837](https://jira.hl7.org/browse/FHIR-52837)

--- a/input/resources/au-ps-patient.xml
+++ b/input/resources/au-ps-patient.xml
@@ -311,7 +311,7 @@
         </extension>
       </extension>
       <path value="Patient.name.text"/>
-      <comment value="Due to the cultural variance around the world a consuming system may not know how to present the name correctly; moreover, not all the parts of the name go in given or family. Creators are therefore strongly encouraged to provide through this element a presented version of the name. Future versions of this guide may require this element"/>
+      <comment value="Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present, no content is included in the text that isn't found in a part.&#xA;&#xA;Due to cultural variance around the world, a consuming system may not know how to present the name correctly; moreover, not all parts of a name go in given or family. Producers are therefore strongly encouraged to populate a presented version of the name using this element."/>
     </element>
     <element id="Patient.name.family">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">


### PR DESCRIPTION
This PR provides fix for [FHIR-51877](https://jira.hl7.org/browse/FHIR-51877): add the obligation **SHOULD**:able-to-populate on Patient.name.text (formal equivalent of “strongly encourage”) and include a IPS guidance describing the reason for this in the element comment so the guidance appears in the StructureDefinition.

Changes applied:
- AU PS Patient
   - add **SHOULD**:able-to-populate on `Patient.name.text` for the AU PS Producer
   - add IPS guidance on population of Patient.name.text to `ElementDefinition.comment`, as per Jira ticket
- Change Log 
   - added two entries reflecting the above changes 