### PR TITLE
Consistently refer to the FHIR spec as "the FHIR standard"

### DIFF
--- a/input/pagecontent/general-guidance.md
+++ b/input/pagecontent/general-guidance.md
@@ -24,7 +24,7 @@ It is anticipated that extension profiles may be included in future releases of 
 AU PS does not define any search capabilities. It is anticipated that search parameter profiles may be included in future releases of this IG.
 
 #### Terminology Approach
-AU PS does not define any new terminology FHIR artefacts. Terminology supported in AU PS are published in AU Base, the base FHIR specification, HL7 Terminology (THO), or the National Clinical Terminology Service (NCTS). As part of profiling, AU PS inherits the AU Core localised terminology and indicates [local support expectations](the-aups.html#terminology) for an AU PS actor using _Must Support_ and Obligations. 
+AU PS does not define any new terminology FHIR artefacts. Terminology supported in AU PS are published in AU Base, the FHIR standard, HL7 Terminology (THO), or the National Clinical Terminology Service (NCTS). As part of profiling, AU PS inherits the AU Core localised terminology and indicates [local support expectations](the-aups.html#terminology) for an AU PS actor using _Must Support_ and Obligations. 
 
 ### Profile Approach
 AU PS resource profiles:

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -1,6 +1,6 @@
 This page includes the value sets and code systems supported in AU Patient Summary (AU PS).  
 
-AU PS does not define any unique terminology FHIR artefacts. Terminology supported in AU PS are published in [AU Base](https://build.fhir.org/ig/hl7au/au-fhir-base/terminology.html), the base FHIR specification, [HL7 Terminology (THO)](https://terminology.hl7.org/), or the [National Clinical Terminology Service (NCTS)](https://www.healthterminologies.gov.au/).
+AU PS does not define any unique terminology FHIR artefacts. Terminology supported in AU PS are published in [AU Base](https://build.fhir.org/ig/hl7au/au-fhir-base/terminology.html), the FHIR standard, [HL7 Terminology (THO)](https://terminology.hl7.org/), or the [National Clinical Terminology Service (NCTS)](https://www.healthterminologies.gov.au/).
 
 <div class="stu-note">
 Implementers are advised to take note that expansions of value sets visible in this guide may differ from expansions returned with a server using <a href="http://terminology.hl7.org">HL7 Terminology (THO)</a> version 6.0.0 or higher.

--- a/input/resources/au-ps-bundle.xml
+++ b/input/resources/au-ps-bundle.xml
@@ -11,7 +11,7 @@
   <name value="AUPSBundle"/>
   <title value="AU PS Bundle"/>
   <status value="active"/>
-  <description value="This profile sets minimum expectations for a Bundle resource in the context of a patient summary in an Australian context. It is based on [core FHIR Bundle](http://hl7.org/fhir/StructureDefinition/Bundle), and applies the constraints of [Bundle (IPS)](http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips) and AU Patient Summary (AU PS).&#xD;&#xA;AU PS is specified in this guide as a HL7 FHIR document (a Bundle including a Composition), composed by a set of potentially reusable 'minimal' data blocks (the AU PS profiles)."/>
+  <description value="This profile sets minimum expectations for a Bundle resource in the context of a patient summary in an Australian context. It is based on FHIR [Bundle](http://hl7.org/fhir/StructureDefinition/Bundle), and applies the constraints of [Bundle (IPS)](http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips) and AU Patient Summary (AU PS).&#xD;&#xA;AU PS is specified in this guide as a HL7 FHIR document (a Bundle including a Composition), composed by a set of potentially reusable 'minimal' data blocks (the AU PS profiles)."/>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="Bundle"/>


### PR DESCRIPTION
Fix for backlog task [Consistently refer to the FHIR spec as "the FHIR standard"](https://github.com/orgs/hl7au/projects/25/views/1?pane=issue&itemId=148562022).