### PR TITLE
Examples page - update 8.1.1 table to align with the guidance page

### DIFF
--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -216,71 +216,84 @@ The table below identifies some major characteristics of the examples defined in
 </table>
 
 
-#### Missing Data, Empty Sections, Known Absence of Data and Suppressed Data
+#### Missing Data, Empty Sections, Known Absence of Data, No Known X and Suppressed Data
 The table below indicates the elements within examples that demonstrate aspects of [Missing Data, Empty Sections, Known Absence of Data](general-requirements.html#missing-data-empty-sections-known-absence-of-data). 
 
 <table border="1" style="width: 100%; margin: auto; border-collapse: collapse;">
     <thead>
         <tr style="background-color: #f2f2f2;">
             <th>AU PS Bundle example</th>
+            <th><a href="Bundle-aups-basicsummary.html">Basic Summary</a></th>
+            <th><a href="Bundle-aups-noknownx.html">No Known X</a></th>
             <th><a href="Bundle-aups-section-emptyreason.html">Section empty reason</a></th>
             <th><a href="Bundle-aups-gpvisit-retrieval.html">Jeramy 27 May</a></th>
             <th><a href="Bundle-aups-referral-endoconsult-autogen.html">Joyce 07 November 2024</a></th>
-            <th><a href="Bundle-aups-noknownx.html">No Known X</a></th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td rowspan="3"><strong>Missing Data</strong></td>
-            <td rowspan="3"><code>Patient.birthDate</code></td>
-            <td><code>MedicationRequest.authoredOn</code></td>
-            <td rowspan="3"><code>Observation.performer</code></td>
             <td rowspan="3">-</td>
+            <td rowspan="3">-</td>
+            <td rowspan="3">Patient.birthDate</td>
+            <td>MedicationRequest.authoredOn</td>
+            <td rowspan="3">Observation.performer</td>
+        </tr>
+         <tr>
+             <td>Immunization.occurrenceDateTime</td>
         </tr>
         <tr>
-            <td><code>Immunization.occurrenceDateTime</code></td>
-        </tr>
-        <tr>
-            <td><code>Observation.performer</code></td>
+            <td>Observation.performer</td>
         </tr>
         <tr>
             <td rowspan="4"><strong>Empty Sections</strong></td>
-            <td><code>Composition.section:sectionProblems</code></td>
             <td rowspan="4">-</td>
             <td rowspan="4">-</td>
+            <td>Composition.section:sectionProblems</td>
+            <td rowspan="4">-</td>
             <td rowspan="4">-</td>
         </tr>
         <tr>
-            <td><code>Composition.section:sectionAllergies</code></td>
+            <td>Composition.section:sectionAllergies</td>
         </tr>
         <tr>
-            <td><code>Composition.section:sectionMedications</code></td>
+            <td>Composition.section:sectionMedications</td>
         </tr>
         <tr>
-            <td><code>Composition.section:sectionImmunizations</code></td>
+            <td>Composition.section:sectionImmunizations</td>
         </tr>
         <tr>
-            <td rowspan="3"><strong>Known Absence of Data</strong></td>
+            <td><strong>Known Absence of Data Due to Workflow</strong></td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td rowspan="3"><strong>No Known X</strong></td>
+            <td rowspan="3">Condition.code</td>
+            <td>AllergyIntolerance.code</td>
             <td rowspan="3">-</td>
             <td rowspan="3">-</td>
             <td rowspan="3">-</td>
-            <td><code>AllergyIntolerance.code</code></td>
         </tr>
         <tr>
-            <td><code>MedicationStatement.medicationCodeableConcept</code></td>
+            <td>MedicationStatement.medicationCodeableConcept</td>
         </tr>
         <tr>
-            <td><code>Condition.code</code></td>
+            <td>Condition.code</td>
         </tr>
         <tr>
             <td rowspan="2"><strong>Suppressed Data</strong></td>
-            <td><code>Patient.identifier</code></td>
             <td rowspan="2">-</td>
+            <td rowspan="2">-</td>
+            <td>Patient.identifier</td>
             <td rowspan="2">-</td>
             <td rowspan="2">-</td>
         </tr>
         <tr>
-            <td><code>Patient.gender</code></td>
+            <td>Patient.gender</td>
         </tr>
     </tbody>
 </table>

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -222,7 +222,7 @@ The table below indicates the elements within examples that demonstrate aspects 
 <table border="1" style="width: 100%; margin: auto; border-collapse: collapse;">
     <thead>
         <tr style="background-color: #f2f2f2;">
-            <th>AU PS Bundle example</th>
+            <th style="width:25%;">AU PS Bundle example</th>
             <th><a href="Bundle-aups-basicsummary.html">Basic Summary</a></th>
             <th><a href="Bundle-aups-noknownx.html">No Known X</a></th>
             <th><a href="Bundle-aups-section-emptyreason.html">Section empty reason</a></th>

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -235,32 +235,32 @@ The table below indicates the elements within examples that demonstrate aspects 
             <td rowspan="3"><strong>Missing Data</strong></td>
             <td rowspan="3">-</td>
             <td rowspan="3">-</td>
-            <td rowspan="3">Patient.birthDate</td>
-            <td>MedicationRequest.authoredOn</td>
-            <td rowspan="3">Observation.performer</td>
+            <td rowspan="3"><code>Patient.birthDate</code></td>
+            <td><code>MedicationRequest.authoredOn</code></td>
+            <td rowspan="3"><code>Observation.performer</code></td>
         </tr>
          <tr>
-             <td>Immunization.occurrenceDateTime</td>
+             <td><code>Immunization.occurrenceDateTime</code></td>
         </tr>
         <tr>
-            <td>Observation.performer</td>
+            <td><code>Observation.performer</code></td>
         </tr>
         <tr>
             <td rowspan="4"><strong>Empty Sections</strong></td>
             <td rowspan="4">-</td>
             <td rowspan="4">-</td>
-            <td>Composition.section:sectionProblems</td>
+            <td><code>Composition.section:sectionProblems</code></td>
             <td rowspan="4">-</td>
             <td rowspan="4">-</td>
         </tr>
         <tr>
-            <td>Composition.section:sectionAllergies</td>
+            <td><code>Composition.section:sectionAllergies</code></td>
         </tr>
         <tr>
-            <td>Composition.section:sectionMedications</td>
+            <td><code>Composition.section:sectionMedications</code></td>
         </tr>
         <tr>
-            <td>Composition.section:sectionImmunizations</td>
+            <td><code>Composition.section:sectionImmunizations</code></td>
         </tr>
         <tr>
             <td><strong>Known Absence of Data Due to Workflow</strong></td>
@@ -272,28 +272,28 @@ The table below indicates the elements within examples that demonstrate aspects 
         </tr>
         <tr>
             <td rowspan="3"><strong>No Known X</strong></td>
-            <td rowspan="3">Condition.code</td>
-            <td>AllergyIntolerance.code</td>
+            <td rowspan="3"><code>Condition.code</code></td>
+            <td><code>AllergyIntolerance.code</code></td>
             <td rowspan="3">-</td>
             <td rowspan="3">-</td>
             <td rowspan="3">-</td>
         </tr>
         <tr>
-            <td>MedicationStatement.medicationCodeableConcept</td>
+            <td><code>MedicationStatement.medicationCodeableConcept</code></td>
         </tr>
         <tr>
-            <td>Condition.code</td>
+            <td><code>Condition.code</code></td>
         </tr>
         <tr>
             <td rowspan="2"><strong>Suppressed Data</strong></td>
             <td rowspan="2">-</td>
             <td rowspan="2">-</td>
-            <td>Patient.identifier</td>
+            <td><code>Patient.identifier</code></td>
             <td rowspan="2">-</td>
             <td rowspan="2">-</td>
         </tr>
         <tr>
-            <td>Patient.gender</td>
+            <td><code>Patient.gender</code></td>
         </tr>
     </tbody>
 </table>

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -227,6 +227,7 @@ The table below indicates the elements within examples that demonstrate aspects 
             <th><a href="Bundle-aups-noknownx.html">No Known X</a></th>
             <th><a href="Bundle-aups-section-emptyreason.html">Section empty reason</a></th>
             <th><a href="Bundle-aups-gpvisit-retrieval.html">Jeramy 27 May</a></th>
+            <th><a href="Bundle-aups-referral-endoconsult-curated.html">Joyce 28 October</a></th>
             <th><a href="Bundle-aups-referral-endoconsult-autogen.html">Joyce 07 November 2024</a></th>
         </tr>
     </thead>
@@ -237,6 +238,7 @@ The table below indicates the elements within examples that demonstrate aspects 
             <td rowspan="3">-</td>
             <td rowspan="3"><code>Patient.birthDate</code></td>
             <td><code>MedicationRequest.authoredOn</code></td>
+            <td rowspan="3">-</td>
             <td rowspan="3"><code>Observation.performer</code></td>
         </tr>
          <tr>
@@ -250,6 +252,7 @@ The table below indicates the elements within examples that demonstrate aspects 
             <td rowspan="4">-</td>
             <td rowspan="4">-</td>
             <td><code>Composition.section:sectionProblems</code></td>
+            <td rowspan="4">-</td>
             <td rowspan="4">-</td>
             <td rowspan="4">-</td>
         </tr>
@@ -269,13 +272,15 @@ The table below indicates the elements within examples that demonstrate aspects 
             <td>-</td>
             <td>-</td>
             <td>-</td>
+            <td>-</td>
         </tr>
         <tr>
             <td rowspan="3"><strong>No Known X</strong></td>
             <td rowspan="3"><code>Condition.code</code></td>
             <td><code>AllergyIntolerance.code</code></td>
             <td rowspan="3">-</td>
-            <td rowspan="3">-</td>
+            <td rowspan="3"><code>AllergyIntolerance.code</code></td>
+            <td rowspan="3"><code>AllergyIntolerance.code</code></td>
             <td rowspan="3">-</td>
         </tr>
         <tr>
@@ -289,6 +294,7 @@ The table below indicates the elements within examples that demonstrate aspects 
             <td rowspan="2">-</td>
             <td rowspan="2">-</td>
             <td><code>Patient.identifier</code></td>
+            <td rowspan="2">-</td>
             <td rowspan="2">-</td>
             <td rowspan="2">-</td>
         </tr>


### PR DESCRIPTION
Changes made to 8.1.1 table to align with the Guidance section 2.1.4 (Missing Data, Empty Sections, Known Absence of Data):
- Updated section heading to include No Known X
- Renamed 'Known Absence of Data' to 'No Known X'
- Added row for 'Known Absence of Data Due to Workflow' (no examples currently available)
- Added missing No Known X entry for Basic Summary
- Reordered example columns to align with the above