### PR TITLE
AU PS Consumer and Producer to AFMM 2 (FHIR-56422)

### DIFF
--- a/input/resources/au-ps-actor-consumer.xml
+++ b/input/resources/au-ps-actor-consumer.xml
@@ -2,7 +2,7 @@
 <ActorDefinition xmlns="http://hl7.org/fhir">
   <id value="au-ps-actor-consumer"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="2"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/ps/ActorDefinition/au-ps-actor-consumer" />
   <name value="AUPSConsumer"/> 

--- a/input/resources/au-ps-actor-producer.xml
+++ b/input/resources/au-ps-actor-producer.xml
@@ -2,7 +2,7 @@
 <ActorDefinition xmlns="http://hl7.org/fhir">
   <id value="au-ps-actor-producer"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="2"/> 
   </extension>
   <url value="http://hl7.org.au/fhir/ps/ActorDefinition/au-ps-actor-producer" />
   <name value="AUPSProducer"/> 


### PR DESCRIPTION
Addresses [FHIR-56422](https://jira.hl7.org/browse/FHIR-56422)
* Change AU PS Consumer and AU PS Producer actor definition to AFMM 2.

Endorsed by [FHIR WG 20/5/26](https://confluence.hl7.org/spaces/HAFWG/pages/453910696/2026-05-20+FHIRWG+Meeting+Minutes).