### PR TITLE
Adopt the centralized pipeline: release-triggered preprod + QA gate

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -1,0 +1,47 @@
+name: AU PS — build / preview / release to preprod
+
+# Thin caller for the CENTRALIZED reusable pipeline in hl7au/publications. The full build → preview →
+# preprod-deploy logic lives once at hl7au/publications/.github/workflows/build-review-publish.yml;
+# this stub just forwards au-fhir-ps's events to it. subtree="ps" → au-ps owns only the /fhir/ps
+# subtree (au-base owns the /fhir root); the reusable workflow scopes the preprod sync accordingly and
+# uploads only the shared root files au-ps read-modify-writes.
+#
+# RELEASE FLOW: publication/release branches are never merged to master (master = CI build). Cut a
+# GitHub RELEASE targeting the release branch → this builds and deploys to PREPROD (staging). PROD is
+# NOT published from here: promotion is a manual, HL7 AU-only step in the publications repo
+# (Actions → "Promote preprod → prod"), which copies the approved preprod content to prod. See the
+# reusable workflow + publications docs/publication-process.md for the full design.
+#
+# The legacy pipeline-build.yml / pipeline-release.yml (self-hosted, /webroot → prod) are LEFT in place
+# for now as a fallback; they trigger only on a pushed tag, so they do not overlap this stub's events.
+
+on:
+  push:
+    branches: [master]          # CI validation build only (no deploy)
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]          # a GitHub release → build + deploy to preprod (staging)
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag/branch of au-fhir-ps to build"
+        default: master
+      deploy_preprod:
+        description: "Deploy this build to preprod (on-demand branch staging behind the real CloudFront setup)"
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  pipeline:
+    uses: hl7au/publications/.github/workflows/build-review-publish.yml@master
+    with:
+      subtree: "ps"                                        # au-ps owns only the /fhir/ps subtree
+      ref: ${{ inputs.ref || '' }}
+      deploy_preprod: ${{ inputs.deploy_preprod || false }}
+      qa_max_errors: 8                                     # QA gate: current baseline is 8 errors — ratchet down as they're fixed
+    secrets: inherit


### PR DESCRIPTION
Migrates au-fhir-ps onto the centralized reusable pipeline in `hl7au/publications`, matching au-fhir-base and au-fhir-core (paired with hl7au/publications#12).

- Adds a `build-review-publish.yml` **caller stub** (`subtree: "ps"`).
- **Deploy to preprod on a GitHub release** (`published`); prod is promoted manually from the publications repo (`Actions → "Promote preprod → prod"`), HL7 AU only.
- **QA gate** baseline `qa_max_errors: 8` (au-ps's current error count) — the build fails on a new (9th) error; ratchet down as they're fixed.

The legacy `pipeline-build.yml` / `pipeline-release.yml` (self-hosted, `/webroot → prod`) are **left in place** as a fallback for now; they trigger on a pushed tag only, so they do not overlap this stub's events.

> Depends on hl7au/publications#12 (the reusable workflow). Merge that first.